### PR TITLE
Add dietary restriction filters to menu page

### DIFF
--- a/src/components/Menu/MenuFilter.jsx
+++ b/src/components/Menu/MenuFilter.jsx
@@ -1,0 +1,61 @@
+import React, { useState, useEffect } from 'react';
+import { Card } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+
+const DIETARY_OPTIONS = [
+  { id: 'gluten-free', label: 'Gluten Free' },
+  { id: 'dairy-free', label: 'Dairy Free' },
+  { id: 'dairy-optional', label: 'Dairy Optional' },
+  { id: 'contains-tree-nuts', label: 'Contains Tree Nuts' },
+  { id: 'contains-eggs', label: 'Contains Eggs' },
+  { id: 'contains-dairy', label: 'Contains Dairy' },
+  { id: 'contains-gluten', label: 'Contains Gluten' },
+  { id: 'contains-cashews', label: 'Contains Cashews' },
+];
+
+const MenuFilter = ({ onFilterChange }) => {
+  const [selectedFilters, setSelectedFilters] = useState(() => {
+    // Load saved filters from localStorage
+    const savedFilters = localStorage.getItem('dietaryFilters');
+    return savedFilters ? JSON.parse(savedFilters) : [];
+  });
+
+  useEffect(() => {
+    // Save filters to localStorage whenever they change
+    localStorage.setItem('dietaryFilters', JSON.stringify(selectedFilters));
+    // Notify parent component of filter changes
+    onFilterChange(selectedFilters);
+  }, [selectedFilters, onFilterChange]);
+
+  const handleFilterChange = (filterId) => {
+    setSelectedFilters((prev) => {
+      if (prev.includes(filterId)) {
+        return prev.filter((id) => id !== filterId);
+      }
+      return [...prev, filterId];
+    });
+  };
+
+  return (
+    <Card className="p-6 mb-6">
+      <h2 className="text-lg font-semibold mb-4">Dietary Preferences</h2>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {DIETARY_OPTIONS.map(({ id, label }) => (
+          <div key={id} className="flex items-center space-x-2">
+            <Checkbox
+              id={id}
+              checked={selectedFilters.includes(id)}
+              onCheckedChange={() => handleFilterChange(id)}
+            />
+            <Label htmlFor={id} className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+              {label}
+            </Label>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+};
+
+export default MenuFilter;

--- a/src/components/Menu/MenuPage.jsx
+++ b/src/components/Menu/MenuPage.jsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { MEAL_DATA } from '../../data/mealData';
+import MenuFilter from './MenuFilter';
+import MealCard from './MealCard';
+
+const MenuPage = () => {
+  const [dietaryFilters, setDietaryFilters] = useState([]);
+
+  const filterMeals = (meals, filters) => {
+    if (filters.length === 0) return meals;
+
+    return meals.filter(meal => {
+      // If any of the selected filters are in the meal's dietary tags, show the meal
+      return filters.some(filter => meal.dietaryTags.includes(filter));
+    });
+  };
+
+  const renderMealSection = (title, meals) => {
+    const filteredMeals = filterMeals(meals, dietaryFilters);
+
+    return (
+      <div className="mb-8">
+        <h2 className="text-2xl font-bold mb-4">{title}</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filteredMeals.map((meal) => (
+            <MealCard key={meal.id} meal={meal} />
+          ))}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-6">Our Menu</h1>
+      
+      <MenuFilter onFilterChange={setDietaryFilters} />
+
+      {renderMealSection('Breakfast', MEAL_DATA.breakfast)}
+      {renderMealSection('Lunch', MEAL_DATA.lunch)}
+      {renderMealSection('Dinner', MEAL_DATA.dinner)}
+    </div>
+  );
+};
+
+export default MenuPage;


### PR DESCRIPTION
This PR moves dietary restrictions from account settings to a filter component in the menu page. Key changes:

1. Added new MenuFilter component with:
   - Checkbox-based dietary restriction filters
   - Local storage to persist user preferences
   - Responsive grid layout

2. Updated MenuPage to:
   - Use the new MenuFilter component
   - Filter meals based on selected preferences
   - Show all meals when no filters are selected

The changes improve user experience by:
- Making dietary preferences immediately accessible on the menu page
- Persisting preferences across sessions using localStorage
- Allowing users to quickly toggle preferences without account changes

Testing:
- Verify that filters persist after page refresh
- Check responsive layout on mobile and desktop
- Confirm filtering logic works as expected
- Validate accessibility of checkbox inputs